### PR TITLE
Remove argparse from non-CLI calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Requirements
 
 - Python 3.6 or later
 - Jinja2 Python package is required (will be included automatically if Eddy is installed via pip)
-- pytest and pytest-mock Python packages are requried to run the unit tests
+- pytest and pytest-mock Python packages are required to run the unit tests
 
 <details>
   <summary>Example HTML outputs</summary>

--- a/eddymc/eddy.py
+++ b/eddymc/eddy.py
@@ -135,16 +135,6 @@ def get_args(filename=None, scaling_factor=None):
         crit_case (bool): True if kcode case, otherwise False
     """
 
-    parser = argparse.ArgumentParser(description='MCNP or SCALE output to HTML Converter')
-    parser.add_argument("-o", "--file", help="MCNP or SCALE output file")
-    parser.add_argument("-sf", "--scaling_factor", type=float, help="Scaling Factor")
-    # Note: args will be an argparse Namespace object, with the values for args.file and args.scaling_factor
-    # set to None if no cli arguments have been passed.
-    args = parser.parse_args()
-
-    # get filename, and check file exists
-    if args.file:
-        filename = args.file
     filename = get_filename(filename)
 
     # get contents of file
@@ -159,8 +149,6 @@ def get_args(filename=None, scaling_factor=None):
         scaling_factor = 1
     else:
         # Ask for scaling factor for shielding cases, and check it is a valid float.
-        if args.scaling_factor:
-            scaling_factor = args.scaling_factor
         scaling_factor = get_scaling_factor(scaling_factor)
        
     print(f"Output file: {filename}")
@@ -188,4 +176,11 @@ def main(filename=None, scaling_factor=None):
 
 
 if __name__ == "__main__":
-    main()
+    # Eddy should only take command line args if run as __main__
+    parser = argparse.ArgumentParser(description='MCNP or SCALE output to HTML Converter')
+    parser.add_argument("-o", "--file", help="MCNP or SCALE output file")
+    parser.add_argument("-sf", "--scaling_factor", type=float, help="Scaling Factor")
+    # Note: args will be an argparse Namespace object, with the values for args.file and args.scaling_factor
+    # set to None if no cli arguments have been passed.
+    args = parser.parse_args()
+    main(filename=args.file, scaling_factor=args.scaling_factor)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme:
 
 setuptools.setup(
     name="eddy_mc", 
-    version="0.1.1",
+    version="0.1.2",
     author="Cerberus Nuclear",
     author_email="nuclear@cerberusnuclear.com",
     description="Eddy, the MCNP and SCALE HTML output converter",

--- a/tests/test_eddy.py
+++ b/tests/test_eddy.py
@@ -125,33 +125,6 @@ def test_get_scaling_factor_with_invalid_arg_passed():
         eddy.get_scaling_factor(sf)
 
 
-def test_get_args_with_cli_args(mocker, f2_file):
-    # arrange
-    data = f2_file
-    mocker.patch(
-        'eddymc.eddy.argparse.ArgumentParser.parse_args',
-        return_value=Namespace(file='mcnp_examples/F2.out', scaling_factor=3.141592)
-    )
-    # act
-    name, output_data, sf, crit = eddy.get_args()
-    # assert
-    assert name == 'mcnp_examples/F2.out'
-    assert output_data == data
-    assert sf == 3.141592
-    assert crit is False
-
-
-def test_get_args_with_invalid_cli_scaling_factor(mocker):
-    # arrange
-    mocker.patch(
-        'eddymc.eddy.argparse.ArgumentParser.parse_args',
-        return_value=Namespace(file='mcnp_examples/F2.out', scaling_factor='parrot')
-    )
-    # act, assert
-    with pytest.raises(ValueError):
-        eddy.get_args()
-
-
 def test_get_args_with_passed_arguments(mocker, f2_file):
     # arrange
     name = 'mcnp_examples/F2.out'
@@ -248,12 +221,3 @@ def test_main_with_nonexistent_input_passed(mocker):
         eddy.main(name)
 
 
-def test_main_with_nonexistent_cli_input(mocker):
-    # arrange
-    mocker.patch(
-        'eddymc.eddy.argparse.ArgumentParser.parse_args',
-        return_value=Namespace(file='mcnp_examples/nonexistent_file.txt', scaling_factor=None),
-    )
-    # act, assert
-    with pytest.raises(AssertionError):
-        eddy.main()


### PR DESCRIPTION
Argparse should only be called when run as __main__ from CLI