### PR TITLE
Fix issue 22 - Calls to static files now use upper case

### DIFF
--- a/eddymc/mcnp/mcnp_html_writer.py
+++ b/eddymc/mcnp/mcnp_html_writer.py
@@ -67,7 +67,7 @@ def get_html(filename, inline_css):
     mcnp_input = sanitize_input(gv.mcnp_input)
     #with open("static/MCNP_template.html", "r") as file:
     #    html_template = file.read()
-    html_template = pkg_resources.read_text(static, 'mcnp_template.html')
+    html_template = pkg_resources.read_text(static, 'MCNP_template.html')
     template = Template(html_template)
     html = template.render(
         filename=filename, # with path

--- a/eddymc/scale/scale_html_writer.py
+++ b/eddymc/scale/scale_html_writer.py
@@ -59,7 +59,7 @@ def get_html(filename, inline_css):
         html (str): the html output as a single string
     """
     scale_input = sanitize_input(gv.scale_input)
-    html_template = pkg_resources.read_text(static, 'scale_template.html')
+    html_template = pkg_resources.read_text(static, 'SCALE_template.html')
     template = Template(html_template)
     case_name, extension = os.path.splitext(filename)
     case_name = case_name.replace('\\', '/').split('/')[-1]


### PR DESCRIPTION
There was an issue with mcnp_html_writer.py and scale_mcnp_writer.py calling static files "mcnp_template.html" when the actual file is "MCNP_template.html", this didn't seem to cause a problem on windows but caused linux cases to fail. 