### PR TITLE
New reset() function in eddy.py to re-initialise global variables

### DIFF
--- a/eddymc/eddy.py
+++ b/eddymc/eddy.py
@@ -34,14 +34,13 @@ import argparse
 from tkinter import Tk, simpledialog
 from tkinter.filedialog import askopenfilename
 # Local imports
-# none
 
 if __name__ == "__main__":
-    from scale import scale_converter
-    from mcnp import mcnp_converter
+    from scale import scale_converter, scale_global_variables as sgv
+    from mcnp import mcnp_converter, global_variables as gv
 else:
-    from .scale import scale_converter
-    from .mcnp import mcnp_converter
+    from .scale import scale_converter, scale_global_variables as sgv
+    from .mcnp import mcnp_converter, global_variables as gv
 
 
 def check_if_crit(output_data):
@@ -155,6 +154,48 @@ def get_args(filename=None, scaling_factor=None):
     return filename, output_data, scaling_factor, crit_case
 
 
+def reset():
+    """This function resets all the global variables
+    in both the mcnp and scale files to correct a bug when
+    eddy.main is called within a loop, or called multiple times.
+    It is intended that this should be replaced by removing the
+    global_variables files and implementing a new EddyCase class
+    to hold the information."""
+    gv.f = None
+    gv.scaling_factor = 1
+    gv.date_time = {}
+    gv.rundate = None
+    gv.runtime = None
+    gv.parameters = {}
+    gv.cell_list = []
+    gv.tally_list = []
+    gv.f_types = []
+    gv.F2_tallies = {'neutrons': [], 'photons': [], 'electrons': []}
+    gv.F4_tallies = {'neutrons': [], 'photons': [], 'electrons': []}
+    gv.F5_tallies = {'neutrons': [], 'photons': [], 'electrons': []}
+    gv.F6_tallies = {'neutrons': [], 'photons': [], 'electrons': [], 'Collision Heating': []}
+    gv.tally_types = {}
+    gv.fatal_errors = []
+    gv.warnings = []
+    gv.comments = []
+    gv.duplicate_surfaces = []
+    gv.particle_list = []
+    gv.k_effective = {}
+    gv.ctme = None
+    gv.nps = None
+    gv.mcnp_input = None
+    gv.crit_case = False
+    gv.cycles = {}
+    gv.lost_particles = False
+
+    sgv.scaling_factor = 1
+    sgv.tally_list = []
+    sgv.rundate = None
+    sgv.runtime = None
+    sgv.mixture_list = []
+    sgv.scale_input = None
+
+
 def main(filename=None, scaling_factor=None):
     """Entry point to Eddy. Can take filename and scaling factor as arguments.
     Call get_args to find the filename & scaling factor if not provided, and also get the
@@ -166,6 +207,7 @@ def main(filename=None, scaling_factor=None):
         filename (optional) (str): the file path (including the name) of the output file
         scaling_factor (optional) (float): A number by which the results will be multiplied
     """
+    reset()
     filename, output_data, scaling_factor, crit_case = get_args(filename, scaling_factor)
     if 'SCALE' in output_data[2]:
         scale_converter.main(filename, scaling_factor)

--- a/eddymc/mcnp/global_variables.py
+++ b/eddymc/mcnp/global_variables.py
@@ -27,3 +27,5 @@ mcnp_input = None
 crit_case = False
 cycles = {}
 lost_particles = False
+
+

--- a/tests/test_eddy.py
+++ b/tests/test_eddy.py
@@ -6,6 +6,7 @@ or add a configuration in pycharm
 import pytest
 from argparse import Namespace
 from eddymc import eddy
+from eddymc.mcnp import global_variables as gv
 from tests import mcnp_examples, scale_examples
 try:
     import importlib.resources as pkg_resources
@@ -263,3 +264,13 @@ def test_main_with_nonexistent_input_passed(mocker):
         eddy.main(name)
 
 
+def test_reset_when_looping(f2_file):
+    # arrange
+    file = "mcnp_examples/F2.out"
+    scaling_factor = 1
+    # act
+    # call eddy.main twice
+    eddy.main(file, scaling_factor)
+    eddy.main(file, scaling_factor)
+    # assert
+    assert len(gv.cell_list) == 5


### PR DESCRIPTION
This fixes issue #30, where the global variable file is not reinitialized when eddy.main() is called multiple times without re-importing the module.

Closes #30 