### PR TITLE
CI, average tallies, unit tests and updates for v0.3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# This workflow will run Eddy's full pytest suite on python versions 3.6, 3.7 and 3.8
+# This workflow will run Eddy's full pytest suite on python versions 3.6, 3.7, 3.8 and 3.9
 # every time there is a push to the master branch or a pull request on the master branch.
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ py==1.9.0
 pyparsing==2.4.7
 pytest
 pytest-mock==3.3.1
+importlib-resources
 six==1.15.0
 toml==0.10.2

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     url="https://github.com/Cerberus-Nuclear/Eddy-Source",
     packages=['eddymc', 'eddymc//mcnp', 'eddymc//scale', 'eddymc//static'],
     package_data={'eddymc//static': ['*']},
-    install_requires=['Jinja2'],
+    install_requires=['Jinja2', 'importlib-resources'],
     classifiers=[
         "Programming Language :: Python :: 3",
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',

--- a/tests/test_eddy.py
+++ b/tests/test_eddy.py
@@ -88,14 +88,14 @@ Solutions tried so far:
     patching various combinations of Tk and withdraw
 """
 
-# def test_get_filename_from_tkinter(mocker):
-#     # arrange
-#     mocker.patch("eddymc.eddy.Tk.withdraw", return_value=None)
-#     mocker.patch("eddymc.eddy.askopenfilename", return_value="mcnp_examples/F2.out")
-#     # act
-#     file = eddy.get_filename()
-#     # assert
-#     assert file == 'mcnp_examples/F2.out'
+def test_get_filename_from_tkinter(mocker):
+    # arrange
+    mocker.patch("eddymc.eddy.Tk.withdraw", return_value=None)
+    mocker.patch("eddymc.eddy.askopenfilename", return_value="mcnp_examples/F2.out")
+    # act
+    file = eddy.get_filename()
+    # assert
+    assert file == 'mcnp_examples/F2.out'
 
 
 def test_get_filename_if_file_missing():

--- a/tests/test_eddy.py
+++ b/tests/test_eddy.py
@@ -13,6 +13,17 @@ except ImportError:
     import importlib_resources as pkg_resources
 
 
+@pytest.fixture()
+def mock_tk(tmpdir):
+    class MockTk:
+        def __init__(self):
+            pass
+
+        def withdraw(self):
+            pass
+    return MockTk
+
+
 @pytest.fixture
 def f2_file(tmpdir):
     f2 = pkg_resources.read_text(mcnp_examples, 'F2.out')
@@ -80,17 +91,17 @@ def test_get_filename_with_passed_name():
     assert filename == file
 
 
-"""This test is commented out because I can't get github workflows to 
-ignore the Tk().withdraw() line, and it errors there because the server 
-can't connect to a display.
-Solutions tried so far:
-    setting the $DISPLAY variable in the workflow (sets the display, but tkinter can't connect)
-    patching various combinations of Tk and withdraw
-"""
-
-def test_get_filename_from_tkinter(mocker):
+def test_get_filename_from_tkinter(mocker, mock_tk):
+    """This test is commented out because I can't get github workflows to
+    ignore the Tk().withdraw() line, and it errors there because the server
+    can't connect to a display.
+    Solutions tried so far:
+        setting the $DISPLAY variable in the workflow (sets the display, but tkinter can't connect)
+        patching various combinations of Tk and withdraw
+    """
     # arrange
-    mocker.patch("eddymc.eddy.Tk.withdraw", return_value=None)
+    mocker.patch('eddymc.eddy.Tk', return_value=mock_tk())
+    #mocker.patch("eddymc.eddy.Tk.withdraw", create=True, return_value=None)
     mocker.patch("eddymc.eddy.askopenfilename", return_value="mcnp_examples/F2.out")
     # act
     file = eddy.get_filename()

--- a/tests/test_eddy.py
+++ b/tests/test_eddy.py
@@ -101,7 +101,6 @@ def test_get_filename_from_tkinter(mocker, mock_tk):
     """
     # arrange
     mocker.patch('eddymc.eddy.Tk', return_value=mock_tk())
-    #mocker.patch("eddymc.eddy.Tk.withdraw", create=True, return_value=None)
     mocker.patch("eddymc.eddy.askopenfilename", return_value="mcnp_examples/F2.out")
     # act
     file = eddy.get_filename()
@@ -135,19 +134,14 @@ def test_get_scaling_factor_with_value_passed_as_string():
     assert scaling_factor == 3.141592
 
 
-"""This test is commented out because I can't get github workflows to 
-ignore the Tk().withdraw() line, and it errors there because the server 
-can't connect to a display. See the comment on test_get_filename_from_tkinter()
-for more details
-"""
-# def test_get_scaling_factor_from_tkinter(mocker):
-#     # arrange
-#     mocker.patch("eddymc.eddy.Tk.withdraw", return_value=None)
-#     mocker.patch("eddymc.eddy.simpledialog.askfloat", return_value=3.141592)
-#     # act
-#     scaling_factor = eddy.get_scaling_factor()
-#     # assert
-#     assert scaling_factor == 3.141592
+def test_get_scaling_factor_from_tkinter(mocker, mock_tk):
+    # arrange
+    mocker.patch('eddymc.eddy.Tk', return_value=mock_tk())
+    mocker.patch("eddymc.eddy.simpledialog.askfloat", return_value=3.141592)
+    # act
+    scaling_factor = eddy.get_scaling_factor()
+    # assert
+    assert scaling_factor == 3.141592
 
 
 def test_get_scaling_factor_with_invalid_arg_passed():


### PR DESCRIPTION
New CI workflow covers python versions 3.6 - 3.9
importlib-resources now listed as required in setup.py and requirements.txt (needed for python 3.6)
Average tallies now work for F2, F4 and F6 tallies
Sorted the 2 unit tests (test_eddy.test_get_filename_from_tkinter and test_eddy.test_get_scaling_factor_from_tkinter) that failed when run on github servers - Tk() is now properly mocked by a MockTk class - closes #25 
setup.py and eddy.spec updated for v0.3.3